### PR TITLE
feat(ui): Add Cancel button to the Login page that clears values entered

### DIFF
--- a/components/forms/account/sign-in-form.tsx
+++ b/components/forms/account/sign-in-form.tsx
@@ -20,11 +20,19 @@ export const SignInForm: React.FC<Props> = (props) => {
   const {
     register,
     handleSubmit,
+    reset,
     formState: { isValid },
   } = useForm<TSignInValidator>({
     resolver: zodResolver(SignInValidator),
   });
   const { onFormSubmit } = props;
+
+  const onCancel = () => {
+    reset({
+      email: "",
+      password: "",
+    });
+  };
 
   return (
     <form onSubmit={handleSubmit(onFormSubmit)}>
@@ -52,6 +60,16 @@ export const SignInForm: React.FC<Props> = (props) => {
           type="submit"
         >
           Login
+        </Button>
+      </div>
+      <div className="py-2">
+        <Button
+          className="w-full rounded-md"
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+        >
+          Cancel
         </Button>
       </div>
       <div className="py-2 text-center">


### PR DESCRIPTION
### Summary
Adds a **Cancel** button to the Sign In form that clears the form inputs by calling `react-hook-form`’s `reset()`. This closes #37.

### What changed
- Updated `SignInForm` to also destructure `reset` from `useForm(...)`.
- Added an `onCancel` handler that resets the form values:
  - `email: ""`
  - `password: ""`
- Added a new **Cancel** button under the existing **Login** button:
  - `type="button"` (prevents accidental submit)
  - `variant="outline"`
  - `onClick={onCancel}`

### Rationale
Users need an easy way to clear out entered credentials and start over without manually deleting input values.

### UX / UI Notes
- Cancel button is full-width and placed in its own `py-2` container beneath Login for clear separation.
- Uses an outline style to visually distinguish it from the primary Login action.