### PR TITLE
feat(PLN-8): Add cancel button to login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# University of Belize - CI/CD Cohort
+
 # Plane App UI
 **What is CS Pro Plane App?**
 

--- a/components/forms/account/sign-in-form.tsx
+++ b/components/forms/account/sign-in-form.tsx
@@ -11,12 +11,19 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import React from "react";
 import { useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
 
 interface Props {
   onFormSubmit: (formData: IEmailPasswordFormValues) => void;
 }
 
+/*
+  Author: Tysha Daniels
+  Purpose: Added Cancel button to sign-in form (PLN-102)
+*/
+
 export const SignInForm: React.FC<Props> = (props) => {
+  const router = useRouter();
   const {
     register,
     handleSubmit,
@@ -25,6 +32,10 @@ export const SignInForm: React.FC<Props> = (props) => {
     resolver: zodResolver(SignInValidator),
   });
   const { onFormSubmit } = props;
+
+  const handleCancel = () => {
+    router.push("/");
+  };
 
   return (
     <form onSubmit={handleSubmit(onFormSubmit)}>
@@ -52,6 +63,16 @@ export const SignInForm: React.FC<Props> = (props) => {
           type="submit"
         >
           Login
+        </Button>
+      </div>
+      <div className="py-2">
+        <Button
+          className="w-full border rounded-md"
+          variant="outline"
+          type="button"
+          onClick={handleCancel}
+        >
+          Cancel
         </Button>
       </div>
       <div className="py-2 text-center">


### PR DESCRIPTION
## Summary
Adds a Cancel button to the sign-in form on the login page.

## Changes
- Added Cancel button below the Login button in [sign-in-form.tsx](cci:7://file:///home/eudora/Documents/2025-2/Software%20Engineering%20%28CMPS4131%29/devops/session01/cspro-ub/cspro-plane-ui/components/forms/account/sign-in-form.tsx:0:0-0:0)
- Clicking Cancel redirects the user to the home page (`/`)

## Jira
Closes PLN-8
