### PR TITLE
feat: Improve mobile responsiveness of issue status cards

### DIFF
--- a/app/workspaces/_components/cards/issue-status-card.tsx
+++ b/app/workspaces/_components/cards/issue-status-card.tsx
@@ -1,17 +1,31 @@
 import React from 'react';
+import { LucideIcon } from "lucide-react";
 
 interface Props {
   count: number;
   description: string;
+  icon: LucideIcon; // dynamically add an appropriate icon
+  color?: string; // dynamically set icon color (optional)
+  hoverBg?: string; // card hover background color (optional)
 }
 
-export const IssueStatusCard: React.FC<Props> = ({ count, description }) => {
+export const IssueStatusCard: React.FC<Props> = ({ count, description, icon: Icon, color = "text-gray-500", hoverBg = "hover:bg-gray-50" }) => {
   return (
-    <div className="w-full flex flex-col gap-2 hover:bg-slate-50 rounded-tl-xl lg:rounded-l-xl">
+    /* Apply hover background color */
+    <div className={`w-full flex flex-col gap-2 ${hoverBg} rounded-tl-xl lg:rounded-l-xl`}>
       <a href="#" className="py-4 duration-300 rounded-[10px] w-full ">
-        <div className="relative flex pl-10 sm:pl-20 md:pl-20 lg:pl-20 items-center">
+        <div className="relative flex pl-10 items-center gap-2">
+          {/* Icon */}
+          {Icon && (
+            <div className={`p-2 rounded-lg bg-gray-100 ${color}`}>
+              <Icon size={20} />
+            </div>
+          )}
+
+          {/* Text Description */}
           <div>
-            <h5 className="font-semibold text-xl">{count}</h5>
+            {/* Apply color to count */}
+            <h5 className={`font-semibold text-xl ${color}`}>{count}</h5>
             <p className="custom-text-color text-sm xl:text-base">
               {description}
             </p>

--- a/app/workspaces/_components/dashboard-overview.tsx
+++ b/app/workspaces/_components/dashboard-overview.tsx
@@ -43,7 +43,7 @@ export const DashboardOverView: React.FC = () => {
  
           <div className="grid lg:grid-cols-2 gap-7">
             <div className="lg:col-span-2">
-              <div className="bg-[#ffffff] rounded-xl border-[0.5px] w-full grid lg:grid-cols-4 md:grid-cols-2 sm:grid-cols-2 grid-cols-2 p-0.5 hover:shadow-md duration-300 [&>div>a>div]:border-r [&>div:last-child>a>div]:border-0 [&>div>a>div]:border-2[&>div:nth-child(2)>a>div]:border-0 [&>div:nth-child(2)>a>div]:lg:border-r">
+              <div className="bg-[#ffffff] rounded-xl border-[0.5px] w-full grid lg:grid-cols-4 md:grid-cols-2 sm:grid-cols-2 grid-cols-1 p-0.5 hover:shadow-md duration-300 [&>div>a>div]:border-r [&>div:last-child>a>div]:border-0 [&>div>a>div]:border-2[&>div:nth-child(2)>a>div]:border-0 [&>div:nth-child(2)>a>div]:lg:border-r">
                 {/* Render issue status cards with an icon and in color */}
                 <IssueStatusCard count={0} description="Issues Assigned" icon={ListTodo} color="text-blue-500" hoverBg="hover:bg-blue-50"/>
                 <IssueStatusCard count={0} description="Issues Created" icon={Clock} color="text-yellow-500" hoverBg="hover:bg-yellow-50"/>

--- a/app/workspaces/_components/dashboard-overview.tsx
+++ b/app/workspaces/_components/dashboard-overview.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import DashboardHeader from "./headers/dashboard-header";
 import { useMobxStore } from "@/store/store.provider";
+import { CheckCircle, Clock, AlertTriangle, ListTodo} from "lucide-react"; // issue status card icons
  
 /*
   Author: Fidha Noushad on May 20th, 2024
@@ -16,6 +17,7 @@ import { useMobxStore } from "@/store/store.provider";
   Props: None
   updated by: - Mohammed Rifad on May 23nd, 2024 - added reusable dashboard header
               - Muhammed Adnan on May 25th, 2024 - Sticky header, removed multi-scrollbar's
+              - Andres Hung on April 3rd, 2026 - Add icons and color to issue status cards
 
 */
 
@@ -42,10 +44,11 @@ export const DashboardOverView: React.FC = () => {
           <div className="grid lg:grid-cols-2 gap-7">
             <div className="lg:col-span-2">
               <div className="bg-[#ffffff] rounded-xl border-[0.5px] w-full grid lg:grid-cols-4 md:grid-cols-2 sm:grid-cols-2 grid-cols-2 p-0.5 hover:shadow-md duration-300 [&>div>a>div]:border-r [&>div:last-child>a>div]:border-0 [&>div>a>div]:border-2[&>div:nth-child(2)>a>div]:border-0 [&>div:nth-child(2)>a>div]:lg:border-r">
-                <IssueStatusCard count={0} description="Issues Assigned" />
-                <IssueStatusCard count={0} description="Issues Created" />
-                <IssueStatusCard count={0} description="Issues Overdue" />
-                <IssueStatusCard count={0} description="Issues Completed" />
+                {/* Render issue status cards with an icon and in color */}
+                <IssueStatusCard count={0} description="Issues Assigned" icon={ListTodo} color="text-blue-500" hoverBg="hover:bg-blue-50"/>
+                <IssueStatusCard count={0} description="Issues Created" icon={Clock} color="text-yellow-500" hoverBg="hover:bg-yellow-50"/>
+                <IssueStatusCard count={0} description="Issues Overdue" icon={AlertTriangle} color="text-red-500" hoverBg="hover:bg-red-50"/>
+                <IssueStatusCard count={0} description="Issues Completed" icon={CheckCircle} color="text-green-500" hoverBg="hover:bg-green-50"/>
               </div>
             </div>
 


### PR DESCRIPTION
### Summary

Using `grid-cols-1` instead of `grid-cols-2` in the container holding the `IssueStatusCard` components improves the visuals on smaller screens. Closes #56 

### Rationale

Before, the text would slightly overflow.

### Changes Made

Changed the styling of the container.

#### Before

<img width="632" height="467" alt="before" src="https://github.com/user-attachments/assets/d4df02e2-c60f-4141-b73f-ceb1096401d0" />

#### After

<img width="632" height="593" alt="after" src="https://github.com/user-attachments/assets/26444719-3d69-401a-af55-8f17c4c4cd4c" />
