### PR TITLE
feat(ui): implement card component and refactor sign-in UI

### DIFF
--- a/app/(authentication)/(sign-in)/page.tsx
+++ b/app/(authentication)/(sign-in)/page.tsx
@@ -7,9 +7,9 @@ import { AuthService } from "@/services/auth.service";
 import { Toast } from "@/lib/toast/toast";
 import { ToastContainer } from "react-toastify";
 import { useMobxStore } from "@/store/store.provider";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";
+import Link from "next/link";
 import { Spinner } from "@/components/spinner";
-import { FormHeading } from "@/components/form-elements/form-heading";
-import FormDescription from "@/components/form-elements/form.description";
  
 /*
   Author: Mohammed Rifad on April 12th, 2024
@@ -57,46 +57,58 @@ const SignInPage = () => {
   }, [fetchCurrentUser, handleLoginRedirection]);
 
     const onFormSubmit = async (formData: IEmailPasswordFormValues) => {
-
+      setLoading(true); // Show spinner immediately when Login is clicked
 
       return authService.userSignIn(formData).then((response) => {
         if (response?.statusCode == 200) {
           toast.showToast("success", response?.message);
-          setLoading(true);
           mutateUserInfo();
         } else {
-          setLoading(false);
+          setLoading(false); // Hide spinner so user can try again
           toast.showToast("error", response?.message);
         }
+      }).catch(() => {
+        setLoading(false); // Hide spinner if the request itself fails (network error, etc.)
+        toast.showToast("error", "Something went wrong. Please try again.");
       });
-
-      
-      
     };
 
   return (
     <>
-      {isLoading ? (
-        <div className="flex justify-center items-center h-full">
-          <Spinner size="large" />
-        </div>
-      ) : (
-        <>
-          <div className="flex justify-center items-center h-full">
-            <div className="max-w-xl px-4 w-full">
-              <FormHeading headingText="Welcome Back to CS Pro !!" />
+  <div className="flex justify-center items-center h-full">
+    <Card className="max-w-xl w-full mx-4">
+      <CardHeader className="text-center">
+        <CardTitle>Welcome Back to CS Pro !!</CardTitle>
+        <CardDescription>
+          Get back to your issues, projects and workspaces.
+        </CardDescription>
+      </CardHeader>
 
-              <FormDescription descriptionText="Get back to your issues, projects and workspaces." />
-
-              <div>
-                <SignInForm onFormSubmit={onFormSubmit} />
-              </div>
+      <CardContent>
+        <div className="relative">
+          {isLoading && (
+            <div className="absolute inset-0 flex items-center justify-center bg-card/80 z-10 rounded-md">
+              <Spinner size="large" />
             </div>
-            <ToastContainer />
+          )}
+          <div className={isLoading ? "opacity-50 pointer-events-none" : ""}>
+            <SignInForm onFormSubmit={onFormSubmit} />
           </div>
-        </>
-      )}
-    </>
+        </div>
+      </CardContent>
+
+      <CardFooter className="justify-center gap-1">
+        <span className="text-sm text-muted-foreground">
+          Don&apos;t have an account?
+        </span>
+        <Link href="/sign-up" className="text-sm text-primary hover:underline">
+          Signup
+        </Link>
+      </CardFooter>
+    </Card>
+    <ToastContainer />
+  </div>
+</>
   );
 };
 

--- a/components/forms/account/sign-in-form.tsx
+++ b/components/forms/account/sign-in-form.tsx
@@ -28,35 +28,32 @@ export const SignInForm: React.FC<Props> = (props) => {
 
   return (
     <form onSubmit={handleSubmit(onFormSubmit)}>
-      <div className="py-2">
-         
-        <Input
-          className="w-full border rounded-md"
-          placeholder="Enter your email"
-          {...register("email")}
-        />
-      </div>
+      <div className="space-y-4">
+        <div>
+          <Input
+            className="w-full border rounded-md"
+            placeholder="Enter your email"
+            {...register("email")}
+          />
+        </div>
 
-      <div className="py-2">
-        <Input
-          className="w-full border rounded-md"
-          placeholder="Enter your password"
-          type="password"
-          {...register("password")}
-        />
-      </div>
-      <div className="py-2">
-        <Button
-          className="w-full border rounded-md"
-          disabled={!isValid}
-          type="submit"
-        >
-          Login
-        </Button>
-      </div>
-      <div className="py-2 text-center">
-        <span className="bg-slate-50"> Dont have an account?</span>
-        <Link href="/sign-up"> Signup</Link>
+        <div>
+          <Input
+            className="w-full border rounded-md"
+            placeholder="Enter your password"
+            type="password"
+            {...register("password")}
+          />
+        </div>
+        <div>
+          <Button
+            className="w-full border rounded-md"
+            disabled={!isValid}
+            type="submit"
+          >
+            Login
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border border-border bg-card text-card-foreground shadow-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};


### PR DESCRIPTION
- Created reusable Card component (Header, Title, Content, Footer) using shadcn/ui pattern.
- Refactored the sign-in page to use the new Card layout for improved typography, spacing, and elevation.
- Cleaned up the sign-in form by extracting the signup link into the CardFooter.
- Fixed the loading spinner state to trigger immediately on form submission.
- Added a loading spinner overlay to the CardContent to maintain form context during API calls.

<img width="1920" height="1109" alt="Screenshot_20260418_032311" src="https://github.com/user-attachments/assets/a65c3686-20c6-4e81-b34d-3cf0455991ac" />

<img width="1920" height="1113" alt="Screenshot_20260418_032355" src="https://github.com/user-attachments/assets/b3dc5a4e-d177-49e6-9636-352cca021cb8" />
