### PR TITLE
feat(ui): implement UI components for Reset Password flow

### DIFF
--- a/app/(authentication)/(sign-in)/page.tsx
+++ b/app/(authentication)/(sign-in)/page.tsx
@@ -7,10 +7,17 @@ import { AuthService } from "@/services/auth.service";
 import { Toast } from "@/lib/toast/toast";
 import { ToastContainer } from "react-toastify";
 import { useMobxStore } from "@/store/store.provider";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+import Link from "next/link";
 import { Spinner } from "@/components/spinner";
-import { FormHeading } from "@/components/form-elements/form-heading";
-import FormDescription from "@/components/form-elements/form.description";
- 
+
 /*
   Author: Mohammed Rifad on April 12th, 2024
   Purpose: Renders sign-in page
@@ -29,11 +36,10 @@ const SignInPage = () => {
   } = useMobxStore();
 
   const handleLoginRedirection = useCallback(
-   
     (user: IUser) => {
-       console.log('is onboarders', user.is_onboarded)
+      console.log("is onboarders", user.is_onboarded);
       if (!user.is_onboarded) {
-        console.log('redirecting...')
+        console.log("redirecting...");
         router.push("/onboarding");
         return;
       }
@@ -46,20 +52,21 @@ const SignInPage = () => {
         if (workspaceSlug) router.push(`/workspaces/${workspaceSlug}`);
       });
     },
-    [router]
+    [router],
   );
 
   const mutateUserInfo = useCallback(() => {
-
     fetchCurrentUser().then((user) => {
       handleLoginRedirection(user);
     });
   }, [fetchCurrentUser, handleLoginRedirection]);
 
-    const onFormSubmit = async (formData: IEmailPasswordFormValues) => {
+  const onFormSubmit = async (formData: IEmailPasswordFormValues) => {
+    setLoading(true);
 
-
-      return authService.userSignIn(formData).then((response) => {
+    return authService
+      .userSignIn(formData)
+      .then((response) => {
         if (response?.statusCode == 200) {
           toast.showToast("success", response?.message);
           setLoading(true);
@@ -68,34 +75,53 @@ const SignInPage = () => {
           setLoading(false);
           toast.showToast("error", response?.message);
         }
+      })
+      .catch(() => {
+        setLoading(false);
+        toast.showToast("error", "Something went wrong. Please try again.");
       });
-
-      
-      
-    };
+  };
 
   return (
     <>
-      {isLoading ? (
-        <div className="flex justify-center items-center h-full">
-          <Spinner size="large" />
-        </div>
-      ) : (
-        <>
-          <div className="flex justify-center items-center h-full">
-            <div className="max-w-xl px-4 w-full">
-              <FormHeading headingText="Welcome Back to CS Pro !!" />
+      <div className="flex justify-center items-center h-full">
+        <Card className="max-w-xl w-full mx-4">
+          <CardHeader className="text-center">
+            <CardTitle>Welcome back to CS Pro!</CardTitle>
+            <CardDescription>
+              Start managing your projects, issues and workspaces once more.
+            </CardDescription>
+          </CardHeader>
 
-              <FormDescription descriptionText="Get back to your issues, projects and workspaces." />
-
-              <div>
+          <CardContent>
+            <div className="relative">
+              {isLoading && (
+                <div className="absolute inset-0 flex items-center justify-center bg-card/80 z-10 rounded-md">
+                  <Spinner size="large" />
+                </div>
+              )}
+              <div
+                className={isLoading ? "opacity-50 pointer-events-none" : ""}
+              >
                 <SignInForm onFormSubmit={onFormSubmit} />
               </div>
             </div>
-            <ToastContainer />
-          </div>
-        </>
-      )}
+          </CardContent>
+
+          <CardFooter className="justify-center gap-1">
+            <span className="text-sm text-muted-foreground">
+              Don&apos;t have an account?
+            </span>
+            <Link
+              href="/sign-up"
+              className="text-sm text-primary hover:underline"
+            >
+              Signup
+            </Link>
+          </CardFooter>
+        </Card>
+        <ToastContainer />
+      </div>
     </>
   );
 };

--- a/app/(authentication)/forgot-password/page.tsx
+++ b/app/(authentication)/forgot-password/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+import React, { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ToastContainer } from "react-toastify";
+import { Spinner } from "@/components/spinner";
+import { ForgotPasswordForm } from "@/components/forms/account/forgot-password-form";
+import { AuthService } from "@/services/auth.service";
+import { Toast } from "@/lib/toast/toast";
+import { TForgotPasswordValidator } from "@/lib/validators/account/forgotpassword.validator";
+
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+
+const ForgotPasswordPage = () => {
+  const router = useRouter();
+  const authService = new AuthService();
+  const toast = new Toast();
+  const [isLoading, setIsLoading] = useState(false);
+  const [emailSent, setEmailSent] = useState(false);
+
+  const onFormSubmit = async (formData: TForgotPasswordValidator) => {
+    setIsLoading(true);
+    try {
+      const response = await authService.forgotPassword(formData.email);
+      if (response?.statusCode === 200) {
+        setEmailSent(true);
+        toast.showToast(
+          "success",
+          response?.message ?? "Check your inbox for the reset password link!",
+        );
+      } else {
+        toast.showToast("error", response?.message ?? "Something went wrong.");
+      }
+    } catch {
+      toast.showToast("error", "Something went wrong. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex justify-center items-center h-full">
+        <Card className="max-w-xl w-full mx-4">
+          <CardHeader className="text-center">
+            <CardTitle>Forgotten Password?</CardTitle>
+            <CardDescription>
+              {emailSent
+                ? "Check your inbox!"
+                : "Enter your email to receive a password reset link."}
+            </CardDescription>
+          </CardHeader>
+
+          {!emailSent && (
+            <CardContent>
+              <div className="relative">
+                {isLoading && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-card/80 z-10 rounded-md">
+                    <Spinner size="large" />
+                  </div>
+                )}
+                <div
+                  className={isLoading ? "opacity-50 pointer-events-none" : ""}
+                >
+                  <ForgotPasswordForm
+                    onFormSubmit={onFormSubmit}
+                    isLoading={isLoading}
+                  />
+                </div>
+              </div>
+            </CardContent>
+          )}
+
+          {emailSent && (
+            <CardContent className="flex justify-center">
+              <button
+                className="text-sm text-primary hover:underline"
+                onClick={() => setEmailSent(false)}
+              >
+                Didn&apos;t receive the email? Try again
+              </button>
+            </CardContent>
+          )}
+
+          <CardFooter className="justify-center gap-1">
+            <span className="text-sm text-muted-foreground">
+              Remember your password?
+            </span>
+            <Link href="/" className="text-sm text-primary hover:underline">
+              Sign In
+            </Link>
+          </CardFooter>
+        </Card>
+      </div>
+      <ToastContainer />
+    </>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/app/(authentication)/reset-password/page.tsx
+++ b/app/(authentication)/reset-password/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+import React, { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { ToastContainer } from "react-toastify";
+import { Spinner } from "@/components/spinner";
+import { ResetPasswordForm } from "@/components/forms/account/reset-password-form";
+import { AuthService } from "@/services/auth.service";
+import { Toast } from "@/lib/toast/toast";
+import { TResetPasswordValidator } from "@/lib/validators/account/resetpassword.validator";
+
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+
+const ResetPasswordContent = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const authService = new AuthService();
+  const toast = new Toast();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const uid = searchParams.get("uid") ?? "";
+  const token = searchParams.get("token") ?? "";
+
+  const onFormSubmit = async (formData: TResetPasswordValidator) => {
+    if (!uid || !token) {
+      toast.showToast("error", "Invalid or expired reset link.");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await authService.resetPassword(
+        uid,
+        token,
+        formData.newPassword,
+      );
+      if (response?.statusCode === 200) {
+        toast.showToast(
+          "success",
+          response?.message ?? "Password reset successfully!",
+        );
+        setTimeout(() => router.push("/"), 2000);
+      } else {
+        toast.showToast(
+          "error",
+          response?.message ?? "Reset failed. The link may have expired.",
+        );
+      }
+    } catch {
+      toast.showToast("error", "Something went wrong. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex justify-center items-center h-full">
+      <Card className="max-w-xl w-full mx-4">
+        <CardHeader className="text-center">
+          <CardTitle>Reset Your Password</CardTitle>
+          <CardDescription>
+            Choose a strong new password for your account.
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent>
+          <div className="relative">
+            {isLoading && (
+              <div className="absolute inset-0 flex items-center justify-center bg-card/80 z-10 rounded-md">
+                <Spinner size="large" />
+              </div>
+            )}
+            <div className={isLoading ? "opacity-50 pointer-events-none" : ""}>
+              <ResetPasswordForm
+                onFormSubmit={onFormSubmit}
+                isLoading={isLoading}
+              />
+            </div>
+          </div>
+        </CardContent>
+
+        <CardFooter className="justify-center gap-1">
+          <span className="text-sm text-muted-foreground">Back to</span>
+          <Link href="/" className="text-sm text-primary hover:underline">
+            Sign In
+          </Link>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+};
+
+const ResetPasswordPage = () => {
+  return (
+    <>
+      <Suspense
+        fallback={
+          <div className="flex justify-center items-center h-full">
+            <Spinner size="large" />
+          </div>
+        }
+      >
+        <ResetPasswordContent />
+      </Suspense>
+      <ToastContainer />
+    </>
+  );
+};
+
+export default ResetPasswordPage;

--- a/app/profile/layout.tsx
+++ b/app/profile/layout.tsx
@@ -1,10 +1,16 @@
-"use client"
+"use client";
 import React from "react";
 import { ChevronLeft, LogOut, MoveLeft } from "lucide-react";
 import Link from "next/link";
 import Sidebar from "@/components/sidebar/profile-settings-sidebar/sidebar";
-import { PROFILE_ACTION_LINKS, WORKSPACE_ACTION_LINKS } from "@/constants/profile";
-import "react-toastify/dist/ReactToastify.css";
+import {
+  PROFILE_ACTION_LINKS,
+  WORKSPACE_ACTION_LINKS,
+} from "@/constants/profile";
+// import "react-toastify/dist/ReactToastify.css";
+import { useMobxStore } from "@/store/store.provider";
+import { AuthService } from "@/services/auth.service";
+import { useRouter } from "next/navigation";
 
 /*
   Author: Muhammed Adnan on June 2nd, 2024
@@ -13,7 +19,25 @@ import "react-toastify/dist/ReactToastify.css";
     - children: ReactNode - The content to be rendered within the layout.
 */
 
-const ProfileSettingsLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+const ProfileSettingsLayout: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const authService = new AuthService();
+  const router = useRouter();
+  const {
+    user: { updateUserOnLogout },
+  } = useMobxStore();
+
+  const handleLogout = async () => {
+    try {
+      await authService.userLogout();
+      updateUserOnLogout();
+      router.push("/");
+    } catch (error) {
+      console.error("Logout failed:", error);
+    }
+  };
+
   return (
     <div className="flex h-screen">
       <div className="flex flex-col fixed h-full w-[280px] border-r">
@@ -22,22 +46,34 @@ const ProfileSettingsLayout: React.FC<{ children: React.ReactNode }> = ({ childr
             <ChevronLeft size={20} strokeWidth={1} />
             <h6 className="font-semibold">Profile settings</h6>
           </Link>
-        <h6 className="text-[13px] font-semibold text-gray-500 mt-3 ml-1 mb-1">Your account</h6>
+          <h6 className="text-[13px] font-semibold text-gray-500 mt-3 ml-1 mb-1">
+            Your account
+          </h6>
           <Sidebar RouteList={PROFILE_ACTION_LINKS} />
-        <h6 className="text-[13px] font-semibold text-gray-500 mt-3 ml-1 mb-2 rounded-sm hover:bg">Workspaces</h6>
-        <Link href="/workspaces/dashboard" className="flex items-center justify-center text-[13px] cursor-pointer">
-          <button className="flex w-full items-center gap-x-2 px-3 py-1 rounded-sm hover:bg-gray-200 font-[500]">
-              <span className="flex items-center justify-center h-6 w-6 rounded bg-blue-900 text-white ">S</span>
+          <h6 className="text-[13px] font-semibold text-gray-500 mt-3 ml-1 mb-2 rounded-sm hover:bg">
+            Workspaces
+          </h6>
+          <Link
+            href="/workspaces/dashboard"
+            className="flex items-center justify-center text-[13px] cursor-pointer"
+          >
+            <button className="flex w-full items-center gap-x-2 px-3 py-1 rounded-sm hover:bg-gray-200 font-[500]">
+              <span className="flex items-center justify-center h-6 w-6 rounded bg-blue-900 text-white ">
+                S
+              </span>
               <h6>Workspace Name</h6>
-          </button>
-        </Link>
-        <Sidebar RouteList={WORKSPACE_ACTION_LINKS} />
+            </button>
+          </Link>
+          <Sidebar RouteList={WORKSPACE_ACTION_LINKS} />
         </div>
-        
+
         <div className="bottom-0 left-0 right-0 flex justify-between items-center">
           <div className="ml-3 items-center">
-            <button className="w-full flex items-center justify-start text-red-500 gap-2 p-2">
-              <LogOut size={14}/>
+            <button
+              onClick={handleLogout}
+              className="w-full flex items-center justify-start text-red-500 gap-2 p-2"
+            >
+              <LogOut size={14} />
               <span className="text-[13px] font-[500]">Sign out</span>
             </button>
           </div>

--- a/app/profile/security/page.tsx
+++ b/app/profile/security/page.tsx
@@ -1,10 +1,13 @@
-"use client"
+"use client";
+import React, { useState } from "react";
 import ChangePasswordForm from "@/components/forms/account/change-password-form";
 import { Toast } from "@/lib/toast/toast";
 import { TChangePasswordValidator } from "@/lib/validators/account/changepassword.validator";
-
 import { ProfileService } from "@/services/profile.service";
 import { ToastContainer } from "react-toastify";
+import Link from "next/link";
+import { KeyRound, MailOpen } from "lucide-react";
+
 /*
   Author: Fathima Swabri on July 10, 2024
   Purpose: Display security page under profile settings. 
@@ -12,37 +15,43 @@ import { ToastContainer } from "react-toastify";
 */
 
 const ChangePassword: React.FC = () => {
-
   const profileService = new ProfileService();
   const toast = new Toast();
   const handleFormSubmit = async (formData: TChangePasswordValidator) => {
     try {
-        await profileService.updateUserPassword(formData).then((res) => {
-        console.log(res, "Password updated successfully");  
+      await profileService.updateUserPassword(formData).then((res) => {
+        console.log(res, "Password updated successfully");
         res?.statusCode == 200
-      ? toast.showToast("success", res?.message)
-      : toast.showToast("error", res?.message);
-    })
-      
+          ? toast.showToast("success", res?.message)
+          : toast.showToast("error", res?.message);
+      });
     } catch (error) {
       console.error("Error updating password", error);
+      toast.showToast("error", "Something went wrong. Please try again.");
     }
   };
-  
-  
+
   return (
     <>
-       <ToastContainer />
-       <div className="w-full h-full p-6 bg-white rounded-md ml-[100px]">
-      <div className="w-2/5 p-7">
-      <h1 className="text-3xl font-bold text-gray-900 mb-8">Change password</h1>
-      <ChangePasswordForm onFormSubmit={handleFormSubmit}/>
+      <ToastContainer />
+      <div className="w-full min-h-full p-8 bg-white">
+        <div className="max-w-xl">
+          <div className="flex items-center gap-2 mb-1">
+            <KeyRound size={18} className="text-gray-700" />
+            <h1 className="text-2xl font-bold text-gray-900">
+              Change Password
+            </h1>
+          </div>
+          <p className="text-sm text-gray-500 mb-6">
+            Update your password. You&apos;ll need to know your current password
+            first.
+          </p>
+
+          <ChangePasswordForm onFormSubmit={handleFormSubmit} />
+        </div>
       </div>
-    </div>
-       </>
-    
+    </>
   );
 };
 
 export default ChangePassword;
- 

--- a/app/workspaces/_components/profile-popover.tsx
+++ b/app/workspaces/_components/profile-popover.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import Link from "next/link";
 import { Popover, PopoverContent, PopoverTrigger } from "@nextui-org/react";
-import { CircleUserRound, Settings, LogOut } from "lucide-react";
+import { CircleUserRound, Settings, LogOut, KeyRound } from "lucide-react";
 import { useMobxStore } from "@/store/store.provider";
+import { AuthService } from "@/services/auth.service";
+import { useRouter } from "next/navigation";
 
 /* 
   Author: Sreethu EA on May 23, 2024
@@ -14,25 +16,38 @@ import { useMobxStore } from "@/store/store.provider";
 */
 
 const ProfilePopover: React.FC = () => {
+  const authService = new AuthService();
+  const router = useRouter();
+  const {
+    user: { currentUser, updateUserOnLogout },
+  } = useMobxStore();
 
-  const {user: { currentUser },} = useMobxStore();
-  
-  const displayChar = currentUser?.first_name[0].toUpperCase()
-  const email = currentUser?.email
-  
+  const displayChar = currentUser?.first_name?.[0]?.toUpperCase() || "";
+  const email = currentUser?.email || "";
+
+  const handleLogout = async () => {
+    try {
+      await authService.userLogout();
+      updateUserOnLogout();
+      router.push("/");
+    } catch (error) {
+      console.error("Logout failed:", error);
+    }
+  };
+
   return (
     <>
       <Popover>
         <PopoverTrigger>
           <button className="bg-blue-900 text-white px-2 py-1 mt-1 rounded w-6 h-6 outline-none flex items-center justify-center text-sm">
-          { displayChar }
+            {displayChar}
           </button>
         </PopoverTrigger>
 
         <PopoverContent>
           <div className="px-4 py-5 border-2 border-grey-500 bg-white">
             <div className="flex items-center text-sm text-slate-600">
-              { email }
+              {email}
             </div>
             <br />
 
@@ -56,12 +71,28 @@ const ProfilePopover: React.FC = () => {
             </div>
 
             <br />
+
+            <div className="flex items-center">
+              <Link href="/profile/security" passHref>
+                <div className="flex items-center">
+                  <KeyRound />
+                  <span className="ml-2 text-sm max-w-prose text-slate-600">
+                    Security
+                  </span>
+                </div>
+              </Link>
+            </div>
+
+            <br />
             <hr />
             <div className="flex items-center">
-              <LogOut />
-              <span className="ml-2 text-sm max-w-prose text-slate-600">
-                Sign Out
-              </span>
+              <button
+                onClick={handleLogout}
+                className="flex items-center text-red-500 w-full text-left"
+              >
+                <LogOut className="mr-2" color="red" />
+                <span className="text-sm max-w-prose">Sign Out</span>
+              </button>
             </div>
           </div>
         </PopoverContent>
@@ -70,4 +101,4 @@ const ProfilePopover: React.FC = () => {
   );
 };
 
-export default ProfilePopover;
+export default ProfilePopover;

--- a/app/workspaces/_components/workspace-popover.tsx
+++ b/app/workspaces/_components/workspace-popover.tsx
@@ -82,7 +82,7 @@ const WorkspacePopover: React.FC = () => {
                   >
                     {workspace.name[0].toUpperCase()}
                   </button>
-                  <span className="truncate text-base text-sm font-medium text-slate-600 pl-2">
+                  <span className="truncate text-base font-medium text-slate-600 pl-2">
                     {workspace.name}
                   </span>
                   <div style={{ marginLeft: "70px" }}></div>
@@ -109,17 +109,17 @@ const WorkspacePopover: React.FC = () => {
               </span>
             </div>
             <br />
-            <div className="flex items-center">
+            <Link href="/profile" passHref className="flex items-center">
               <CircleUserRound />
               <span className="ml-2 text-sm max-w-prose text-slate-600">
                 View profiles
               </span>
-            </div>
+            </Link>
             <br />
             <Link  href={`/workspaces/${currentWorkspace}/settings/`} className="flex items-center">
               <Settings />
               <span className="ml-2 text-sm max-w-prose text-slate-600">
-                Settings
+                Workspace Settings
               </span>
             </Link>
             <br />

--- a/components/forms/account/forgot-password-form.tsx
+++ b/components/forms/account/forgot-password-form.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  ForgotPasswordValidator,
+  TForgotPasswordValidator,
+} from "@/lib/validators/account/forgotpassword.validator";
+import { zodResolver } from "@hookform/resolvers/zod";
+import React from "react";
+import { useForm } from "react-hook-form";
+
+interface Props {
+  onFormSubmit: (formData: TForgotPasswordValidator) => void;
+  isLoading?: boolean;
+}
+
+export const ForgotPasswordForm: React.FC<Props> = ({
+  onFormSubmit,
+  isLoading = false,
+}) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid, errors },
+  } = useForm<TForgotPasswordValidator>({
+    resolver: zodResolver(ForgotPasswordValidator),
+    mode: "onChange",
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onFormSubmit)} className="space-y-4">
+      <div>
+        <Input
+          id="forgot-password-email"
+          className="w-full"
+          placeholder="Email Address"
+          type="email"
+          {...register("email")}
+          disabled={isLoading}
+        />
+        {errors.email && (
+          <span className="text-red-500 text-[13px] mt-1 block">
+            {errors.email.message}
+          </span>
+        )}
+      </div>
+
+      <Button
+        id="forgot-password-submit"
+        className="w-full"
+        disabled={!isValid || isLoading}
+        type="submit"
+      >
+        {isLoading ? "Sending..." : "Send Reset Link"}
+      </Button>
+    </form>
+  );
+};

--- a/components/forms/account/reset-password-form.tsx
+++ b/components/forms/account/reset-password-form.tsx
@@ -1,0 +1,110 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  ResetPasswordValidator,
+  TResetPasswordValidator,
+} from "@/lib/validators/account/resetpassword.validator";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Eye, EyeOff } from "lucide-react";
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+
+interface Props {
+  onFormSubmit: (formData: TResetPasswordValidator) => void;
+  isLoading?: boolean;
+}
+
+export const ResetPasswordForm: React.FC<Props> = ({
+  onFormSubmit,
+  isLoading = false,
+}) => {
+  const [showNew, setShowNew] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid, errors },
+  } = useForm<TResetPasswordValidator>({
+    resolver: zodResolver(ResetPasswordValidator),
+    mode: "onChange",
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit(onFormSubmit)}
+      className="space-y-5"
+      autoComplete="off"
+    >
+      <div>
+        <label
+          htmlFor="reset-new-password"
+          className="block text-sm font-medium mb-1"
+        >
+          New Password
+        </label>
+        <div className="relative">
+          <Input
+            id="reset-new-password"
+            className="w-full pr-10"
+            placeholder="New Password"
+            type={showNew ? "text" : "password"}
+            {...register("newPassword")}
+            disabled={isLoading}
+          />
+          <span
+            onClick={() => setShowNew(!showNew)}
+            className="absolute inset-y-0 right-3 flex items-center cursor-pointer text-muted-foreground"
+          >
+            {showNew ? <EyeOff size={18} /> : <Eye size={18} />}
+          </span>
+        </div>
+        {errors.newPassword && (
+          <span className="text-red-500 text-[13px] mt-1 block">
+            {errors.newPassword.message}
+          </span>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="reset-confirm-password"
+          className="block text-sm font-medium mb-1"
+        >
+          Confirm Password
+        </label>
+        <div className="relative">
+          <Input
+            id="reset-confirm-password"
+            className="w-full pr-10"
+            placeholder="Confirm New Password"
+            type={showConfirm ? "text" : "password"}
+            {...register("confirmPassword")}
+            disabled={isLoading}
+          />
+          <span
+            onClick={() => setShowConfirm(!showConfirm)}
+            className="absolute inset-y-0 right-3 flex items-center cursor-pointer text-muted-foreground"
+          >
+            {showConfirm ? <EyeOff size={18} /> : <Eye size={18} />}
+          </span>
+        </div>
+        {errors.confirmPassword && (
+          <span className="text-red-500 text-[13px] mt-1 block">
+            {errors.confirmPassword.message}
+          </span>
+        )}
+      </div>
+
+      <Button
+        id="reset-password-submit"
+        className="w-full"
+        disabled={!isValid || isLoading}
+        type="submit"
+      >
+        {isLoading ? "Resetting..." : "Reset Password"}
+      </Button>
+    </form>
+  );
+};

--- a/components/forms/account/sign-in-form.tsx
+++ b/components/forms/account/sign-in-form.tsx
@@ -9,14 +9,16 @@ import { IEmailPasswordFormValues } from "@/types/user";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
-import React from "react";
+import React, { useState } from "react";
 import { useForm } from "react-hook-form";
+import { Eye, EyeOff } from "lucide-react";
 
 interface Props {
   onFormSubmit: (formData: IEmailPasswordFormValues) => void;
 }
 
 export const SignInForm: React.FC<Props> = (props) => {
+  const [showPassword, setShowPassword] = useState(false);
   const {
     register,
     handleSubmit,
@@ -28,35 +30,48 @@ export const SignInForm: React.FC<Props> = (props) => {
 
   return (
     <form onSubmit={handleSubmit(onFormSubmit)}>
-      <div className="py-2">
-         
-        <Input
-          className="w-full border rounded-md"
-          placeholder="Enter your email"
-          {...register("email")}
-        />
-      </div>
+      <div className="space-y-4">
+        <div>
+          <Input
+            className="w-full border rounded-md"
+            placeholder="Email Address"
+            {...register("email")}
+          />
+        </div>
 
-      <div className="py-2">
-        <Input
-          className="w-full border rounded-md"
-          placeholder="Enter your password"
-          type="password"
-          {...register("password")}
-        />
-      </div>
-      <div className="py-2">
-        <Button
-          className="w-full border rounded-md"
-          disabled={!isValid}
-          type="submit"
-        >
-          Login
-        </Button>
-      </div>
-      <div className="py-2 text-center">
-        <span className="bg-slate-50"> Dont have an account?</span>
-        <Link href="/sign-up"> Signup</Link>
+        <div>
+          <div className="relative">
+            <Input
+              className="w-full border rounded-md"
+              placeholder="Password"
+              type={showPassword ? "text" : "password"}
+              {...register("password")}
+            />
+            <span
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute inset-y-0 right-3 flex items-center cursor-pointer text-gray-400"
+            >
+              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            </span>
+          </div>
+          <div className="flex justify-end mt-1">
+            <Link
+              href="/forgot-password"
+              className="text-xs text-muted-foreground hover:text-primary hover:underline transition-colors"
+            >
+              Forgot password?
+            </Link>
+          </div>
+        </div>
+        <div>
+          <Button
+            className="w-full border rounded-md"
+            disabled={!isValid}
+            type="submit"
+          >
+            Login
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "overflow-hidden rounded-2xl border border-border/60 bg-card/95 text-card-foreground shadow-sm transition-shadow duration-200 hover:shadow-md",
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6 pb-4", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-xl font-semibold leading-tight tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm leading-relaxed text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/lib/validators/account/forgotpassword.validator.ts
+++ b/lib/validators/account/forgotpassword.validator.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const ForgotPasswordValidator = z.object({
+  email: z
+    .string()
+    .email("Please enter a valid email address")
+    .min(1, "Email is required"),
+});
+
+export type TForgotPasswordValidator = z.infer<typeof ForgotPasswordValidator>;

--- a/lib/validators/account/resetpassword.validator.ts
+++ b/lib/validators/account/resetpassword.validator.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const ResetPasswordValidator = z
+  .object({
+    newPassword: z.string().min(6, "Password must be at least 6 characters"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .superRefine(({ newPassword, confirmPassword }, ctx) => {
+    if (newPassword !== confirmPassword) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Passwords do not match",
+        path: ["confirmPassword"],
+      });
+    }
+  });
+
+export type TResetPasswordValidator = z.infer<typeof ResetPasswordValidator>;

--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -47,8 +47,25 @@ export class AuthService extends APIService {
             this.removeRefreshToken();
             return Promise.resolve();
           }
-    
+
+        // Created by: Jennessa Sierra on April 23rd, 2026 - handles forgot password functionality
+        async forgotPassword(email: string): Promise<any> {
+            return this.axiosObj
+                .post(API_BASE_URL + "/api/user/forgot-password/", { email }, { headers: {} })
+                .then((response) => response?.data)
+                .catch((error) => { throw error?.response?.data; });
+        }
+
+        // Created by: Jennessa Sierra on April 23rd, 2026 - handles reset password functionality
+        async resetPassword(uid: string, token: string, newPassword: string): Promise<any> {
+            return this.axiosObj
+                .post(
+                    API_BASE_URL + "/api/user/reset-password/",
+                    { uid, token, new_password: newPassword },
+                    { headers: {} }
+                )
+                .then((response) => response?.data)
+                .catch((error) => { throw error?.response?.data; });
+        }
 }
-
-
   


### PR DESCRIPTION
### Summary

Frontend support for password reset has been implemented, including an interface for resetting the password both when logged out and from within the application. This resolves issue #85.

### Rationale

Users can now access a clear and straightforward interface to recover or update their password, making the process more accessible and reducing friction during account recovery.

### Changes Made

* Added new pages and associated logic to support password reset

#### Sign In Page with Forgot Password

The sign-in screen now includes a “Forgot Password” option, allowing users to initiate the reset process directly.

<img width="745" height="499" alt="image" src="https://github.com/user-attachments/assets/0d1409c0-d0e6-40e1-85b5-9f5b1b2b379d" />

#### Forgot Password Page

A dedicated page has been introduced where users can request a password reset by providing their account details.

<img width="745" height="499" alt="image" src="https://github.com/user-attachments/assets/aff99535-1478-4ac7-a834-1c8847b13da2" />

</br>

<img width="745" height="499" alt="image" src="https://github.com/user-attachments/assets/bba02f37-b642-4644-a19b-ef0aed4cbc54" />

#### Reset Password Page

<img width="745" height="499" alt="image" src="https://github.com/user-attachments/assets/82885785-60a0-4e59-bad2-9f568cfb1781" />
