### PR TITLE
docs: add Tech Stack section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ outstanding results.
 - Dark Mode (coming soon): Switch between light and dark themes for improved accessibility and user comfort.
 - Notifications (coming soon): Receive alerts for issue updates, sprint changes, and important project activity.
 
+## Tech Stack
+
+- Next.js
+- TypeScript
+- Tailwind CSS
+- Axios
+
 ## Installation
 
 Setting up local environment is extremely easy and straight forward. Follow the below step and you will be ready to contribute.


### PR DESCRIPTION
## What changed
Added a Tech Stack section to the README listing the core technologies.

## Why
The README lacked any mention of the frameworks used, making onboarding harder.

## Testing
Documentation-only change. No build impact.

Closes #97 